### PR TITLE
Carto adata added to Loge and User

### DIFF
--- a/app/models/loge.rb
+++ b/app/models/loge.rb
@@ -8,9 +8,19 @@
 #  created_on  :date
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  latitude    :float
+#  longitude   :float
 #
 
 class Loge < ActiveRecord::Base
+  # HACK: We don't want to geocode our Loge [geocoder].
+  geocoder_init(
+    geocode:    false,
+    latitude:   :latitude,
+    longitude:  :longitude,
+    units:      :km
+  )
+
   has_many :memberships
   has_many :users, through: :memberships
   has_many :bookings

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,8 @@
 #  personal_description   :text
 #  neighbour_since        :integer
 #  favorite_shop          :string
+#  latitude               :float
+#  longitude              :float
 #
 # Indexes
 #
@@ -42,4 +44,9 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  # Geocoding
+  geocoded_by :address
+  after_validation :geocode, if: :address_changed?
+
 end

--- a/db/migrate/20150701081626_add_coordinates_to_users.rb
+++ b/db/migrate/20150701081626_add_coordinates_to_users.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :latitude, :float
+    add_column :users, :longitude, :float
+  end
+end

--- a/db/migrate/20150701084028_add_coordinates_to_loges.rb
+++ b/db/migrate/20150701084028_add_coordinates_to_loges.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToLoges < ActiveRecord::Migration
+  def change
+    add_column :loges, :latitude, :float
+    add_column :loges, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150630150533) do
+ActiveRecord::Schema.define(version: 20150701084028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,8 @@ ActiveRecord::Schema.define(version: 20150630150533) do
     t.date     "created_on"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.float    "latitude"
+    t.float    "longitude"
   end
 
   create_table "memberships", force: :cascade do |t|
@@ -108,6 +110,8 @@ ActiveRecord::Schema.define(version: 20150630150533) do
     t.text     "personal_description"
     t.integer  "neighbour_since"
     t.string   "favorite_shop"
+    t.float    "latitude"
+    t.float    "longitude"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,21 +7,27 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
 #Purge the DB
+Membership.destroy_all
 Loge.destroy_all
 User.destroy_all
-Membership.destroy_all
 
 #Create Loge
 loge_10 = Loge.new
   loge_10.name = "Loge du 10ème"
   loge_10.description = "Première loge ouverte"
   loge_10.created_on = Date.new(2015,7,3)
+  # latitude and Longitude on 58 rue de l'Aqueduc, paris"
+  loge_10.latitude = 48.8828091
+  loge_10.longitude = 2.3653419
   loge_10.save
 
 loge_18 = Loge.new
   loge_18.name = "Loge du 18ème"
   loge_18.description = "Lorem ipsum"
   loge_18.created_on = Date.new(2015,9,1)
+  # latitude and Longitude on 4 villa belliard, paris"
+  loge_18.latitude = 48.8953582
+  loge_18.longitude = 2.3291595
   loge_18.save
 
 #Create Users


### PR DESCRIPTION
@RBonsoir, @waffle-iron 
- Add the fields latitude and longitude to the users and loges tables
- Users are geocoded by address, Loges are not geocoded as we hardcoded the latitude and longitude when creating a Loge. Geocoded Init is tweaked in this case to get the geococding methods.